### PR TITLE
Task Import: Support missing Task ExternalId's

### DIFF
--- a/timrlink.net.CLI.Test/TaskImportActionTest.cs
+++ b/timrlink.net.CLI.Test/TaskImportActionTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
@@ -23,28 +24,36 @@ namespace timrlink.net.CLI.Test
 
             var loggerFactory = new LoggerFactory();
 
-            var taskServiceMock = new Mock<ITaskService>(MockBehavior.Loose);
+            var taskServiceMock = new Mock<ITaskService>(MockBehavior.Strict);
             taskServiceMock
-                .Setup(service => service.GetTaskHierarchy()).ReturnsAsync(new List<Task>());
+                .Setup(service => service.GetTaskHierarchy())
+                .ReturnsAsync(new List<Task>());
             taskServiceMock
-                .Setup(service => service.CreateExternalIdDictionary(It.IsAny<IEnumerable<Task>>(), It.IsAny<Func<Task, string>>())).ReturnsAsync(new Dictionary<string, Task>());
+                .Setup(service => service.FlattenTasks(It.IsAny<IEnumerable<Task>>()))
+                .Returns((IEnumerable<Task> tasks) => TaskService.FlattenTasks(tasks));
+            taskServiceMock
+                .Setup(service => service.CreateExternalIdDictionary(It.IsAny<IEnumerable<Task>>(), It.IsAny<Func<Task, string>>()))
+                .ReturnsAsync(new Dictionary<string, Task>());
             taskServiceMock
                 .Setup(service => service.AddTask(It.IsAny<Task>()))
-                .Callback((Task task) => tasks.Add(task));
+                .Callback((Task task) => tasks.Add(task))
+                .Returns(System.Threading.Tasks.Task.CompletedTask);
             taskServiceMock
                 .Setup(service => service.SynchronizeTasksByExternalId(It.IsAny<IDictionary<string, Task>>(), It.IsAny<List<Task>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IEqualityComparer<Task>>()))
-                .Callback((IDictionary<string, Task> _, IList<Task> t, bool u, bool d, IEqualityComparer<Task> e) => tasks.AddRange(t));
+                .Callback((IDictionary<string, Task> _, IList<Task> t, bool u, bool d, IEqualityComparer<Task> e) => tasks.AddRange(t))
+                .Returns(System.Threading.Tasks.Task.CompletedTask);
 
             var importAction = new TaskImportAction(loggerFactory, "data/tasks.csv", false, taskServiceMock.Object);
             await importAction.Execute();
 
             Assert.AreEqual(5, tasks.Count);
+            var taskDictionary = tasks.GroupBy(task => task.uuid).ToDictionary(group => group.Last().externalId, group => group.Last());
 
             {
                 var task = tasks[0];
                 Assert.AreEqual("Customer A", task.name);
                 Assert.AreEqual("Customer A", task.externalId);
-                Assert.IsNull(task.parentExternalId);
+                Assert.IsNull(task.parentUuid);
                 Assert.AreEqual(false, task.bookable);
                 Assert.AreEqual(false, task.billable);
                 Assert.IsNull(task.description);
@@ -56,7 +65,7 @@ namespace timrlink.net.CLI.Test
                 var task = tasks[1];
                 Assert.AreEqual("Project1", task.name);
                 Assert.AreEqual("Customer A|Project1", task.externalId);
-                Assert.AreEqual("Customer A", task.parentExternalId);
+                Assert.AreEqual(taskDictionary["Customer A"].uuid, task.parentUuid);
                 Assert.AreEqual(false, task.bookable);
                 Assert.AreEqual(false, task.billable);
                 Assert.IsNull(task.description);
@@ -68,7 +77,7 @@ namespace timrlink.net.CLI.Test
                 var task = tasks[2];
                 Assert.AreEqual("Task1", task.name);
                 Assert.AreEqual("Customer A|Project1|Task1", task.externalId);
-                Assert.AreEqual("Customer A|Project1", task.parentExternalId);
+                Assert.AreEqual(taskDictionary["Customer A|Project1"].uuid, task.parentUuid);
                 Assert.AreEqual(true, task.bookable);
                 Assert.AreEqual(false, task.billable);
                 Assert.AreEqual("Awesome", task.description);
@@ -81,7 +90,7 @@ namespace timrlink.net.CLI.Test
                 var task = tasks[3];
                 Assert.AreEqual("Project1", task.name);
                 Assert.AreEqual("Customer A|Project1", task.externalId);
-                Assert.AreEqual("Customer A", task.parentExternalId);
+                Assert.AreEqual(taskDictionary["Customer A"].uuid, task.parentUuid);
                 Assert.AreEqual(true, task.bookable);
                 Assert.AreEqual(true, task.billable);
                 Assert.IsTrue(String.IsNullOrEmpty(task.description));
@@ -93,7 +102,7 @@ namespace timrlink.net.CLI.Test
                 var task = tasks[4];
                 Assert.AreEqual("Project2", task.name);
                 Assert.AreEqual("Customer A|Project2", task.externalId);
-                Assert.AreEqual("Customer A", task.parentExternalId);
+                Assert.AreEqual(taskDictionary["Customer A"].uuid, task.parentUuid);
                 Assert.AreEqual(false, task.bookable);
                 Assert.AreEqual(true, task.billable);
                 Assert.IsTrue(String.IsNullOrEmpty(task.description));
@@ -101,7 +110,6 @@ namespace timrlink.net.CLI.Test
                 Assert.IsNull(task.end);
             }
         }
-        
         
         [Test]
         public async System.Threading.Tasks.Task TaskCreationNoUpdateCustomFields()
@@ -113,6 +121,8 @@ namespace timrlink.net.CLI.Test
             var taskServiceMock = new Mock<ITaskService>(MockBehavior.Loose);
             taskServiceMock
                 .Setup(service => service.GetTaskHierarchy()).ReturnsAsync(new List<Task>());
+            taskServiceMock
+                .Setup(service => service.FlattenTasks(It.IsAny<IEnumerable<Task>>())).Returns((IEnumerable<Task> tasks) => TaskService.FlattenTasks(tasks));
             taskServiceMock
                 .Setup(service => service.CreateExternalIdDictionary(It.IsAny<IEnumerable<Task>>(), It.IsAny<Func<Task, string>>())).ReturnsAsync(new Dictionary<string, Task>());
             taskServiceMock
@@ -126,6 +136,7 @@ namespace timrlink.net.CLI.Test
             await importAction.Execute();
 
             Assert.AreEqual(5, tasks.Count);
+            var taskDictionary = tasks.GroupBy(task => task.uuid).ToDictionary(group => group.Last().externalId, group => group.Last());
 
             {
                 var task = tasks[0];
@@ -146,7 +157,7 @@ namespace timrlink.net.CLI.Test
                 var task = tasks[1];
                 Assert.AreEqual("Project1", task.name);
                 Assert.AreEqual("Customer A|Project1", task.externalId);
-                Assert.AreEqual("Customer A", task.parentExternalId);
+                Assert.AreEqual(taskDictionary["Customer A"].uuid, task.parentUuid);
                 Assert.AreEqual(false, task.bookable);
                 Assert.AreEqual(false, task.billable);
                 Assert.IsNull(task.description);
@@ -161,7 +172,7 @@ namespace timrlink.net.CLI.Test
                 var task = tasks[2];
                 Assert.AreEqual("Task1", task.name);
                 Assert.AreEqual("Customer A|Project1|Task1", task.externalId);
-                Assert.AreEqual("Customer A|Project1", task.parentExternalId);
+                Assert.AreEqual(taskDictionary["Customer A|Project1"].uuid, task.parentUuid);
                 Assert.AreEqual(true, task.bookable);
                 Assert.AreEqual(false, task.billable);
                 Assert.AreEqual("Awesome", task.description);
@@ -177,7 +188,7 @@ namespace timrlink.net.CLI.Test
                 var task = tasks[3];
                 Assert.AreEqual("Project1", task.name);
                 Assert.AreEqual("Customer A|Project1", task.externalId);
-                Assert.AreEqual("Customer A", task.parentExternalId);
+                Assert.AreEqual(taskDictionary["Customer A"].uuid, task.parentUuid);
                 Assert.AreEqual(true, task.bookable);
                 Assert.AreEqual(true, task.billable);
                 Assert.IsTrue(String.IsNullOrEmpty(task.description));
@@ -192,7 +203,7 @@ namespace timrlink.net.CLI.Test
                 var task = tasks[4];
                 Assert.AreEqual("Project2", task.name);
                 Assert.AreEqual("Customer A|Project2", task.externalId);
-                Assert.AreEqual("Customer A", task.parentExternalId);
+                Assert.AreEqual(taskDictionary["Customer A"].uuid, task.parentUuid);
                 Assert.AreEqual(false, task.bookable);
                 Assert.AreEqual(true, task.billable);
                 Assert.IsTrue(String.IsNullOrEmpty(task.description));
@@ -201,6 +212,95 @@ namespace timrlink.net.CLI.Test
                 Assert.AreEqual("1", task.customField1);
                 Assert.IsEmpty(task.customField2);
                 Assert.IsEmpty(task.customField3);
+            }
+        }
+
+        [Test]
+        public async System.Threading.Tasks.Task TaskCreationUpdate()
+        {
+            var customerATask = new Task
+            {
+                name = "Customer A",
+                uuid = Guid.NewGuid().ToString(),
+                bookable = false,
+                billable = true
+            };
+            var tasks = new List<Task>();
+
+            var loggerFactory = new LoggerFactory();
+
+            var taskServiceMock = new Mock<ITaskService>(MockBehavior.Strict);
+            taskServiceMock
+                .Setup(service => service.GetTaskHierarchy())
+                .ReturnsAsync(new List<Task> { customerATask });
+            taskServiceMock
+                .Setup(service => service.FlattenTasks(It.IsAny<IEnumerable<Task>>()))
+                .Returns((IEnumerable<Task> tasks) => TaskService.FlattenTasks(tasks));
+            taskServiceMock
+                .Setup(service => service.CreateExternalIdDictionary(It.IsAny<IEnumerable<Task>>(), It.IsAny<Func<Task, string>>()))
+                .ReturnsAsync(new Dictionary<string, Task>());
+            taskServiceMock
+                .Setup(service => service.AddTask(It.IsAny<Task>()))
+                .Callback((Task task) => tasks.Add(task))
+                .Returns(System.Threading.Tasks.Task.CompletedTask);
+            taskServiceMock
+                .Setup(service => service.SynchronizeTasksByExternalId(It.IsAny<IDictionary<string, Task>>(), It.IsAny<List<Task>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IEqualityComparer<Task>>()))
+                .Callback((IDictionary<string, Task> _, IList<Task> t, bool u, bool d, IEqualityComparer<Task> e) => tasks.AddRange(t))
+                .Returns(System.Threading.Tasks.Task.CompletedTask);
+
+            var importAction = new TaskImportAction(loggerFactory, "data/tasks.csv", false, taskServiceMock.Object);
+            await importAction.Execute();
+
+            Assert.AreEqual(4, tasks.Count);
+            var taskDictionary = tasks.GroupBy(task => task.uuid).ToDictionary(group => group.Last().externalId, group => group.Last());
+
+            {
+                var task = tasks[0];
+                Assert.AreEqual("Project1", task.name);
+                Assert.AreEqual("Customer A|Project1", task.externalId);
+                Assert.AreEqual(customerATask.uuid, task.parentUuid);
+                Assert.AreEqual(false, task.bookable);
+                Assert.AreEqual(false, task.billable);
+                Assert.IsNull(task.description);
+                Assert.IsNull(task.start);
+                Assert.IsNull(task.end);
+            }
+
+            {
+                var task = tasks[1];
+                Assert.AreEqual("Task1", task.name);
+                Assert.AreEqual("Customer A|Project1|Task1", task.externalId);
+                Assert.AreEqual(taskDictionary["Customer A|Project1"].uuid, task.parentUuid);
+                Assert.AreEqual(true, task.bookable);
+                Assert.AreEqual(false, task.billable);
+                Assert.AreEqual("Awesome", task.description);
+                Assert.IsNull(task.start);
+                Assert.IsNull(task.end);
+            }
+
+            {
+                // same as task[0] - but update will be performed
+                var task = tasks[2];
+                Assert.AreEqual("Project1", task.name);
+                Assert.AreEqual("Customer A|Project1", task.externalId);
+                Assert.AreEqual(customerATask.uuid, task.parentUuid);
+                Assert.AreEqual(true, task.bookable);
+                Assert.AreEqual(true, task.billable);
+                Assert.IsTrue(String.IsNullOrEmpty(task.description));
+                Assert.IsNull(task.start);
+                Assert.IsNull(task.end);
+            }
+
+            {
+                var task = tasks[3];
+                Assert.AreEqual("Project2", task.name);
+                Assert.AreEqual("Customer A|Project2", task.externalId);
+                Assert.AreEqual(customerATask.uuid, task.parentUuid);
+                Assert.AreEqual(false, task.bookable);
+                Assert.AreEqual(true, task.billable);
+                Assert.IsTrue(String.IsNullOrEmpty(task.description));
+                Assert.AreEqual(new DateTime(2019, 05, 16, 0, 0, 0), task.start);
+                Assert.IsNull(task.end);
             }
         }
     }

--- a/timrlink.net.CLI/Actions/TaskImportAction.cs
+++ b/timrlink.net.CLI/Actions/TaskImportAction.cs
@@ -29,12 +29,38 @@ namespace timrlink.net.CLI.Actions
 
         public override async Task Execute()
         {
-            var tasks = await TaskService.GetTaskHierarchy();
-            var taskDictionary = await TaskService.CreateExternalIdDictionary(tasks);
+            var tasks = TaskService.FlattenTasks(await TaskService.GetTaskHierarchy());
+            var taskUuidDictionary = tasks.ToDictionary(task => task.uuid);
+            var taskTokenDictionary = tasks.ToDictionary(task => Tokenize(task, taskUuidDictionary));
             Logger.LogInformation($"Found {tasks.Count} existing timr root tasks.");
 
             var csvEntries = ParseFile();
             Logger.LogInformation($"CSV contains {csvEntries.Count} entries.");
+            
+            async Task AddTaskTreeRecursive(string parentPath, IList<string> pathTokens)
+            {
+                if (pathTokens.Count == 0) return;
+
+                var name = pathTokens.First();
+                var currentPath = parentPath != null ? parentPath + "|" + name : name;
+
+                if (!taskTokenDictionary.ContainsKey(currentPath))
+                {
+                    var task = new Core.API.Task
+                    {
+                        name = name,
+                        uuid = Guid.NewGuid().ToString(),
+                        parentUuid = string.IsNullOrEmpty(parentPath) ? null : taskTokenDictionary[parentPath].uuid,
+                        externalId = currentPath,
+                        bookable = false,
+                    };
+                    await TaskService.AddTask(task);
+                    taskTokenDictionary.Add(currentPath, task);
+                    taskUuidDictionary.Add(task.uuid, task);
+                }
+
+                await AddTaskTreeRecursive(currentPath, pathTokens.Skip(1).ToList());
+            }
 
             var csvTasks = csvEntries.Select(entry =>
             {
@@ -42,25 +68,12 @@ namespace timrlink.net.CLI.Actions
                 {
                     var taskTokens = entry.Task.Split("|");
                     var parentTaskTokens = taskTokens.SkipLast(1).ToList();
-                    await AddTaskTreeRecursive(taskDictionary, null, parentTaskTokens);
+                    await AddTaskTreeRecursive(null, parentTaskTokens);
 
-                    Core.API.Task task;
-                    if (taskDictionary.TryGetValue(entry.Task, out var existingTask))
-                    {
-                        task = existingTask.Clone();
-                    }
-                    else
-                    {
-                        task = new Core.API.Task
-                        {
-                            externalId = entry.Task,
-                            billable = true,
-                            bookable = true
-                        };
-                    }
-
+                    var task = taskTokenDictionary.TryGetValue(entry.Task, out var existingTask) ? existingTask.Clone() : new Core.API.Task();
                     task.name = taskTokens.Last();
-                    task.parentExternalId = String.Join("|", parentTaskTokens);
+                    task.externalId = entry.Task;
+                    task.parentUuid = taskTokenDictionary[String.Join("|", parentTaskTokens)].uuid;
                     task.bookable = entry.Bookable;
                     task.billable = entry.Billable;
                     task.description = entry.Description;
@@ -71,37 +84,26 @@ namespace timrlink.net.CLI.Actions
                     task.customField1 = entry.CustomField1;
                     task.customField2 = entry.CustomField2;
                     task.customField3 = entry.CustomField3;
-
                     return task;
                 });
-                asyncTask.Wait();
-                return asyncTask.Result;
+                return asyncTask.GetAwaiter().GetResult();
             }).ToList();
 
-            await TaskService.SynchronizeTasksByExternalId(taskDictionary, csvTasks, updateTasks: updateTasks);
+            await TaskService.SynchronizeTasksByExternalId(taskTokenDictionary, csvTasks, updateTasks: updateTasks);
         }
 
-        async Task AddTaskTreeRecursive(IDictionary<string, Core.API.Task> tasks, string parentPath, IList<string> pathTokens)
+        private string Tokenize(Core.API.Task task, Dictionary<string,Core.API.Task> taskUuidDictionary)
         {
-            if (pathTokens.Count == 0) return;
-
-            var name = pathTokens.First();
-            var currentPath = parentPath != null ? parentPath + "|" + name : name;
-
-            if (!tasks.ContainsKey(currentPath))
+            var pathTokens = new List<string>();
+            
+            while (task != null)
             {
-                var task = new Core.API.Task
-                {
-                    name = name,
-                    externalId = currentPath,
-                    parentExternalId = parentPath,
-                    bookable = false,
-                };
-                await TaskService.AddTask(task);
-                tasks.Add(currentPath, task);
+                pathTokens.Add(task.name);
+                task = String.IsNullOrEmpty(task.parentUuid) ? null : taskUuidDictionary[task.parentUuid];
             }
 
-            await AddTaskTreeRecursive(tasks, currentPath, pathTokens.Skip(1).ToList());
+            pathTokens.Reverse();
+            return String.Join('|', pathTokens);
         }
 
         private IList<CSVEntry> ParseFile()

--- a/timrlink.net.Core/Service/TaskService.cs
+++ b/timrlink.net.Core/Service/TaskService.cs
@@ -45,7 +45,12 @@ namespace timrlink.net.Core.Service
             return rootTaskArray.ToList();
         }
 
-        public IList<API.Task> FlattenTasks(IEnumerable<API.Task> tasks)
+        IList<API.Task> ITaskService.FlattenTasks(IEnumerable<API.Task> tasks)
+        {
+            return TaskService.FlattenTasks(tasks);
+        }
+
+        internal static IList<API.Task> FlattenTasks(IEnumerable<API.Task> tasks)
         {
             return tasks.SelectMany(task =>
             {
@@ -108,7 +113,7 @@ namespace timrlink.net.Core.Service
                 }
                 catch (FaultException e)
                 {
-                    logger.LogError($"Failed synchronizing Task(Name={task.name}, ExternalId={task.externalId}): ${e.Message}");
+                    logger.LogError($"Failed synchronizing Task(Name={task.name}, ExternalId={task.externalId}): {e.Message}");
                 }
                 catch (Exception e)
                 {

--- a/timrlink.net.Core/timrlink.net.Core.csproj
+++ b/timrlink.net.Core/timrlink.net.Core.csproj
@@ -19,4 +19,10 @@
   <ItemGroup>
     <WCFMetadata Include="Connected Services" />
   </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>timrlink.net.CLI.Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Previously, when a parent Task with a name already existed, but was missing the appropriate ExternalId, adding would fail, because we tried to add the same Task again (with ExternalId).
Now this Task is taken and the ExternalId gets updated accordingly.

Tried to perform these operations without ExternalId's, only by Task names, but adding missing Tasks doesn't provide uuids in the response of the SOAP API neither takes passed uuids into account when creating those Tasks