### PR TITLE
Project Time Import - Reduce Task Updates only to necessary ones

### DIFF
--- a/timrlink.net.CLI.Test/ProjectTimeXLSXImportActionTest.cs
+++ b/timrlink.net.CLI.Test/ProjectTimeXLSXImportActionTest.cs
@@ -39,7 +39,11 @@ namespace timrlink.net.CLI.Test
                 .Callback((IEnumerable<Core.API.ProjectTime> pts) => projectTimes.AddRange(pts));
 
             var taskServiceMock = new Mock<ITaskService>(MockBehavior.Loose);
-            taskServiceMock.Setup(service => service.CreateExternalIdDictionary(It.IsAny<IEnumerable<Task>>(), It.IsAny<Func<Task, string>>())).ReturnsAsync(new Dictionary<string, Task>());
+            taskServiceMock
+                .Setup(service => service.GetTaskHierarchy()).ReturnsAsync(new List<Task>());
+            taskServiceMock
+                .Setup(service => service.FlattenTasks(It.IsAny<IEnumerable<Task>>()))
+                .Returns<IEnumerable<Task>>(TaskService.FlattenTasks);
 
             var userServiceMock = new Mock<IUserService>(MockBehavior.Strict);
             userServiceMock
@@ -120,7 +124,11 @@ namespace timrlink.net.CLI.Test
                 .Callback((IEnumerable<Core.API.ProjectTime> pts) => projectTimes.AddRange(pts));
 
             var taskServiceMock = new Mock<ITaskService>(MockBehavior.Loose);
-            taskServiceMock.Setup(service => service.CreateExternalIdDictionary(It.IsAny<IEnumerable<Task>>(), It.IsAny<Func<Task, string>>())).ReturnsAsync(new Dictionary<string, Task>());
+            taskServiceMock
+                .Setup(service => service.GetTaskHierarchy()).ReturnsAsync(new List<Task>());
+            taskServiceMock
+                .Setup(service => service.FlattenTasks(It.IsAny<IEnumerable<Task>>()))
+                .Returns<IEnumerable<Task>>(TaskService.FlattenTasks);
 
             var userServiceMock = new Mock<IUserService>(MockBehavior.Strict);
             userServiceMock
@@ -201,7 +209,11 @@ namespace timrlink.net.CLI.Test
                 .Callback((IEnumerable<Core.API.ProjectTime> pts) => projectTimes.AddRange(pts));
 
             var taskServiceMock = new Mock<ITaskService>(MockBehavior.Loose);
-            taskServiceMock.Setup(service => service.CreateExternalIdDictionary(It.IsAny<IEnumerable<Task>>(), It.IsAny<Func<Task, string>>())).ReturnsAsync(new Dictionary<string, Task>());
+            taskServiceMock
+                .Setup(service => service.GetTaskHierarchy()).ReturnsAsync(new List<Task>());
+            taskServiceMock
+                .Setup(service => service.FlattenTasks(It.IsAny<IEnumerable<Task>>()))
+                .Returns<IEnumerable<Task>>(TaskService.FlattenTasks);
 
             var userServiceMock = new Mock<IUserService>(MockBehavior.Strict);
             userServiceMock
@@ -269,7 +281,11 @@ namespace timrlink.net.CLI.Test
                 .Callback((IEnumerable<Core.API.ProjectTime> pts) => projectTimes.AddRange(pts));
 
             var taskServiceMock = new Mock<ITaskService>(MockBehavior.Loose);
-            taskServiceMock.Setup(service => service.CreateExternalIdDictionary(It.IsAny<IEnumerable<Task>>(), It.IsAny<Func<Task, string>>())).ReturnsAsync(new Dictionary<string, Task>());
+            taskServiceMock
+                .Setup(service => service.GetTaskHierarchy()).ReturnsAsync(new List<Task>());
+            taskServiceMock
+                .Setup(service => service.FlattenTasks(It.IsAny<IEnumerable<Task>>()))
+                .Returns<IEnumerable<Task>>(TaskService.FlattenTasks);
 
             var userServiceMock = new Mock<IUserService>(MockBehavior.Strict);
             userServiceMock

--- a/timrlink.net.CLI.Test/data/projecttime_partial_tasks.csv
+++ b/timrlink.net.CLI.Test/data/projecttime_partial_tasks.csv
@@ -1,0 +1,9 @@
+User;Task;StartDateTime;EndDateTime;Break;Notes;Billable
+John Dow;Customer A|Project1|Task1;01.12.15 8:00;01.12.15 16:30;0:30;;false
+John Dow;Customer A|Project1|Task2;02.12.15 8:00;02.12.15 16:30;0:30;;false
+John Dow;Customer A|Project1|Task1;03.12.15 8:00;03.12.15 16:30;0:30;;false
+John Dow;Customer A|Project1|Task3;04.12.15 8:00;04.12.15 16:30;0:30;;false
+John Dow;Customer B|Project1|Task1;26.02.16 8:00;26.02.16 16:30;0:30;"Boring Company, Boring Stuff ";true
+John Dow;Customer B|Project1|Task1;16.03.16 8:00;16.03.16 16:30;0:30;"Boring Company, drilling... ";true
+John Dow;Customer B|Project2|Task1;29.06.16 8:00;29.06.16 16:30;0:30;"Boring Company, drilling... ";true
+John Dow;Customer B|Project2|Task1;29.06.16 8:00;29.06.16 16:30;0:30;"Boring Company, AWESOME Stuff!!! ";true

--- a/timrlink.net.CLI.Test/timrlink.net.CLI.Test.csproj
+++ b/timrlink.net.CLI.Test/timrlink.net.CLI.Test.csproj
@@ -43,5 +43,8 @@
         <None Update="data\tasks_with_subtasks.csv">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Update="data\projecttime_partial_tasks.csv">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 </Project>

--- a/timrlink.net.CLI/Actions/ProjectTimeImportAction.cs
+++ b/timrlink.net.CLI/Actions/ProjectTimeImportAction.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
-using timrlink.net.Core.API;
 using timrlink.net.Core.Service;
 
 namespace timrlink.net.CLI.Actions
@@ -33,7 +32,7 @@ namespace timrlink.net.CLI.Actions
                 return;
             }
 
-            Logger.LogInformation($"found {records.Count} entries");
+            Logger.LogInformation("found {Count} entries", records.Count);
 
             await ImportProjectTimeRecords(records);
         }
@@ -47,67 +46,27 @@ namespace timrlink.net.CLI.Actions
                 .Where(user => user.externalId != null)
                 .GroupBy(user => user.externalId)
                 .ToDictionary(group => group.Key, group => group.ToList());
-            
-            var tasks = await TaskService.GetTaskHierarchy();
-            var taskDictionary = await TaskService.CreateExternalIdDictionary(tasks,
-                task => task.parentExternalId != null ? task.parentExternalId + "|" + task.name : task.name
-            );
-            
+
+            var tasks = TaskService.FlattenTasks(await TaskService.GetTaskHierarchy());
+            var taskTokenDictionary = tasks.ToTokenDictionary();
+
             foreach (var record in records)
             {
                 var externalUserId = record.externalUserId;
                 if (!userDictionary.TryGetValue(externalUserId, out var projectTimeUsers))
                 {
-                    Logger.LogWarning($"User with ExternalId '{externalUserId}' not found. Skipping {record} to import.");
+                    Logger.LogWarning("User with ExternalId '{ExternalUserId}' not found. Skipping {Record} to import.", externalUserId, record);
                     continue;
                 }
                 else if (projectTimeUsers.Count > 1)
                 {
-                    Logger.LogError($"User with ExternalId '{externalUserId}' not unique (logins=[{String.Join(", ", projectTimeUsers.Select(u => u.login))}]). Skipping {record} to import.");
+                    Logger.LogError("User with ExternalId '{ExternalUserId}' not unique (logins=[{Logins}]). Skipping {Record} to import.", externalUserId, String.Join(", ", projectTimeUsers.Select(u => u.login)), record);
                     continue;
                 }
 
-                if (!taskDictionary.ContainsKey(record.externalTaskId))
-                {
-                    try
-                    {
-                        await AddTaskTreeRecursive(taskDictionary, null, record.externalTaskId.Split("|"));
-                    }
-                    catch (Exception e)
-                    {
-                        Logger.LogError(e, $"Failed to add missing Task tree for {record}");
-                        continue;
-                    }
-                }
-
+                await TaskService.AddTaskTreeRecursive(null, record.externalTaskId.Split("|"), taskTokenDictionary, bookable: true);
                 await ProjectTimeService.SaveProjectTime(record);
             }
-        }
-
-        protected async System.Threading.Tasks.Task AddTaskTreeRecursive(IDictionary<string, Task> tasks, string parentPath, IList<string> pathTokens)
-        {
-            if (pathTokens.Count == 0)
-            {
-                return;
-            }
-
-            var name = pathTokens.First();
-            var currentPath = parentPath != null ? parentPath + "|" + name : name;
-            
-            if (!tasks.ContainsKey(currentPath))
-            {
-                Task task = new Task
-                {
-                    name = name,
-                    externalId = currentPath,
-                    parentExternalId = parentPath,
-                    bookable = true,
-                };
-                await TaskService.AddTask(task);
-                tasks.Add(currentPath, task);
-            }
-
-            await AddTaskTreeRecursive(tasks, currentPath, pathTokens.Skip(1).ToList());
         }
     }
 }

--- a/timrlink.net.CLI/Actions/TaskTokenDictionary.cs
+++ b/timrlink.net.CLI/Actions/TaskTokenDictionary.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using timrlink.net.Core.API;
+
+namespace timrlink.net.CLI.Actions
+{
+    internal static class TaskTokenDictionary
+    {
+        public static IDictionary<string, Task> ToTokenDictionary(this IList<Task> tasks)
+        {
+            var taskUuidDictionary = tasks.ToDictionary(task => task.uuid);
+            return tasks.ToDictionary(task => Tokenize(task, taskUuidDictionary));
+        }
+
+        private static string Tokenize(Task task, Dictionary<string, Task> taskUuidDictionary)
+        {
+            var pathTokens = new List<string>();
+
+            while (task != null)
+            {
+                pathTokens.Add(task.name);
+                task = String.IsNullOrEmpty(task.parentUuid) ? null : taskUuidDictionary[task.parentUuid];
+            }
+
+            pathTokens.Reverse();
+            return String.Join('|', pathTokens);
+        }
+    }
+}

--- a/timrlink.net.Core/Service/ITaskService.cs
+++ b/timrlink.net.Core/Service/ITaskService.cs
@@ -10,9 +10,12 @@ namespace timrlink.net.Core.Service
 
         IList<API.Task> FlattenTasks(IEnumerable<API.Task> tasks);
         
+        [Obsolete]
         Task<IDictionary<string, API.Task>> CreateExternalIdDictionary(IEnumerable<API.Task> tasks, Func<API.Task, string> externalIdLookup = null);
 
         Task AddTask(API.Task task);
+
+        Task AddTaskTreeRecursive(string parentPath, IList<string> pathTokens, IDictionary<string, API.Task> taskTokenDictionary, bool bookable);
 
         Task UpdateTask(API.Task task);
 


### PR DESCRIPTION
Instead of assigning externalIds to all Tasks which don't have one yet we now only update the externalId for Tasks which are necessary for the Project Time Import.

Logic for this recursive OnDemand - Task Creation got consolidated and is now reused by Project Time Import and Task Import similarly.

Previously used `CreateExternalIdDictionary` Method got `Obsolete` and should not be used anymore.